### PR TITLE
add more queries to API page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -137,12 +137,7 @@ hr {
 
 // font awesome icons
 i + span {
-  margin-left: 10px;
-}
-h1 {
-  i + span {
-    margin-left: 15px;
-  }
+  margin-left: 0.75em;
 }
 
 // tooltip

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,20 @@ a:hover {
   color: $black;
 }
 
+// code block
+code {
+  padding: 2px 5px;
+  border-radius: 5px;
+  background: $off-black;
+
+  &,
+  * {
+    color: $white;
+    font-family: $mono;
+    font-style: normal;
+  }
+}
+
 // buttons
 button {
   display: inline-flex;

--- a/src/api/genesets.ts
+++ b/src/api/genesets.ts
@@ -22,5 +22,7 @@ export const search = async (query?: string, species?: string[]): Response => {
   params.set("fields", "*");
   params.set("size", "100");
   const url = mygeneset + "query?" + params.toString();
-  return (await request(url)).hits;
+  const { total = 0, hits = [] } = await request(url);
+  if (total && hits.length) hits[0].total = total;
+  return hits;
 };

--- a/src/api/genesets.ts
+++ b/src/api/genesets.ts
@@ -23,6 +23,6 @@ export const search = async (query?: string, species?: string[]): Response => {
   params.set("size", "100");
   const url = mygeneset + "query?" + params.toString();
   const { total = 0, hits = [] } = await request(url);
-  if (total && hits.length) hits[0].total = total;
+  if (hits.length) hits[0].total = total;
   return hits;
 };

--- a/src/api/species.ts
+++ b/src/api/species.ts
@@ -9,7 +9,9 @@ export const search = async (query?: string): Response => {
   params.set("fields", "*");
   params.set("size", "100");
   const url = biothings + "query?" + params.toString();
-  return (await request(url)).hits;
+  const { total = 0, hits = [] } = await request(url);
+  if (total && hits.length) hits[0].total = total;
+  return hits;
 };
 
 export const top = async (): Response => {
@@ -25,5 +27,7 @@ export const top = async (): Response => {
   params = new URLSearchParams();
   params.set("q", ids);
   url = biothings + "query?" + params.toString();
-  return await request(url, "POST");
+  const results = await request(url, "POST");
+  if (results.length) results[0].total = results.length;
+  return results;
 };

--- a/src/api/species.ts
+++ b/src/api/species.ts
@@ -10,7 +10,7 @@ export const search = async (query?: string): Response => {
   params.set("size", "100");
   const url = biothings + "query?" + params.toString();
   const { total = 0, hits = [] } = await request(url);
-  if (total && hits.length) hits[0].total = total;
+  if (hits.length) hits[0].total = total;
   return hits;
 };
 
@@ -21,13 +21,14 @@ export const top = async (): Response => {
   params.set("facet_size", "100");
   params.set("fields", "*");
   let url = mygeneset + "query?" + params.toString();
-  const ids = (await request(url)).facets.taxid.terms
+  const { facets = {}, total = 0 } = await request(url);
+  const ids = facets.taxid.terms
     .map(({ term }: { term: number }) => term)
     .join(",");
   params = new URLSearchParams();
   params.set("q", ids);
   url = biothings + "query?" + params.toString();
   const results = await request(url, "POST");
-  if (results.length) results[0].total = results.length;
+  if (results.length) results[0].total = total;
   return results;
 };

--- a/src/components/Center.vue
+++ b/src/components/Center.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="center" :vertical="vertical" :style="`--width: ${width}`">
+  <div
+    class="center"
+    :vertical="vertical"
+    :compact="compact"
+    :style="`--width: ${width}`"
+  >
     <slot></slot>
   </div>
 </template>
@@ -10,7 +15,8 @@ import { defineComponent } from "vue";
 export default defineComponent({
   props: {
     vertical: Boolean,
-    width: String
+    width: String,
+    compact: Boolean
   }
 });
 </script>
@@ -21,7 +27,7 @@ export default defineComponent({
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
-  margin: 30px auto;
+  margin: 20px auto;
   text-align: center;
   @include trim-v-margins;
 

--- a/src/components/Clickable.vue
+++ b/src/components/Clickable.vue
@@ -83,6 +83,12 @@ export default defineComponent({
   }
 
   &[selected="false"] {
+    background: $theme-pale;
+    color: $black;
+  }
+
+  &[selected="true"] {
+    background: $theme-light;
     color: $black;
   }
 }

--- a/src/components/GenesetEdit.vue
+++ b/src/components/GenesetEdit.vue
@@ -165,9 +165,6 @@ export default defineComponent({
     };
   },
   methods: {
-    removeRow({ originalIndex }: { originalIndex: number }) {
-      console.log(originalIndex);
-    },
     async loadGeneset(id: string) {
       this.loading = true;
       try {

--- a/src/components/SpeciesSelect.vue
+++ b/src/components/SpeciesSelect.vue
@@ -46,6 +46,12 @@
         <span v-if="option.common" class="common">{{ option.common }}</span>
       </span>
     </template>
+    <template v-slot:afterlist>
+      <div class="count">
+        <i class="fas fa-seedling"></i>
+        <span>Top {{ top }} of {{ total }} total results</span>
+      </div>
+    </template>
   </Multiselect>
 </template>
 
@@ -80,7 +86,9 @@ export default defineComponent({
   },
   data() {
     return {
-      value: null
+      value: null,
+      top: "",
+      total: ""
     };
   },
   methods: {
@@ -88,6 +96,10 @@ export default defineComponent({
       let results;
       if (query) results = await search(query);
       else results = top || [];
+
+      // get result counts
+      this.top = Math.min(100, results[0]?.total || 0).toLocaleString();
+      this.total = (results[0]?.total || 0).toLocaleString();
 
       const formatResult = (results: Json) => {
         const key: string = results._id;
@@ -104,7 +116,9 @@ export default defineComponent({
         const icon = findIcon(scientific);
         return { key, scientific, common, full, icon };
       };
+
       results = results.map(formatResult);
+
       return results;
     },
     refresh() {
@@ -135,6 +149,13 @@ $height: 40px - 2px - 2px;
     font-size: 0.8em;
     font-style: italic;
   }
+}
+
+.count {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: $height;
 }
 
 .multiselect {

--- a/src/components/SpeciesSelect.vue
+++ b/src/components/SpeciesSelect.vue
@@ -98,7 +98,7 @@ export default defineComponent({
       else results = top || [];
 
       // get result counts
-      this.top = Math.min(100, results[0]?.total || 0).toLocaleString();
+      this.top = Math.min(100, results.length).toLocaleString();
       this.total = (results[0]?.total || 0).toLocaleString();
 
       const formatResult = (results: Json) => {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,79 +1,82 @@
 <template>
   <div class="table">
-    <table>
-      <thead>
-        <tr>
-          <th v-for="(col, colIndex) in cols" :key="colIndex">
-            <button
-              v-if="col.sortable !== false && !col.action"
-              :align="col.align || 'center'"
-              @click="changeSort(col.name)"
-            >
-              {{ col.name }}
-              <i
-                v-if="col.name === sortCol"
-                :class="`fas fa-sort-${sortUp ? 'up' : 'down'}`"
-              ></i>
-              <i v-else class="fas fa-sort"></i>
-            </button>
-            <div v-else :align="col.align || 'center'">
-              {{ col.name }}
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(row, rowIndex) in _rows" :key="rowIndex">
-          <template v-for="(col, colIndex) in cols" :key="colIndex">
-            <td v-if="col.action" :align="col.align || 'center'">
-              <Clickable
-                :title="col.action"
-                :icon="col.icon"
-                @click="
-                  $emit('action', {
-                    rowIndex,
-                    colIndex,
-                    originalIndex: row.originalIndex,
-                    row,
-                    cell: row[col.key]
-                  })
-                "
-                design="plain"
-              />
-            </td>
-            <td
-              v-else-if="col.format"
-              :align="col.align || 'center'"
-              v-html="col.format(row[col.key])"
-            ></td>
-            <td v-else :align="col.align || 'center'">
-              {{ row[col.key] }}
-            </td>
-          </template>
-        </tr>
-      </tbody>
-    </table>
+    <div class="heading"><slot></slot></div>
+    <div class="scroll">
+      <table>
+        <thead>
+          <tr>
+            <th v-for="(col, colIndex) in cols" :key="colIndex">
+              <button
+                v-if="col.sortable !== false && !col.action"
+                :align="col.align || 'center'"
+                @click="changeSort(col.name)"
+              >
+                {{ col.name }}
+                <i
+                  v-if="col.name === sortCol"
+                  :class="`fas fa-sort-${sortUp ? 'up' : 'down'}`"
+                ></i>
+                <i v-else class="fas fa-sort"></i>
+              </button>
+              <div v-else :align="col.align || 'center'">
+                {{ col.name }}
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, rowIndex) in _rows" :key="rowIndex">
+            <template v-for="(col, colIndex) in cols" :key="colIndex">
+              <td v-if="col.action" :align="col.align || 'center'">
+                <Clickable
+                  :title="col.action"
+                  :icon="col.icon"
+                  @click="
+                    $emit('action', {
+                      rowIndex,
+                      colIndex,
+                      originalIndex: row.originalIndex,
+                      row,
+                      cell: row[col.key]
+                    })
+                  "
+                  design="plain"
+                />
+              </td>
+              <td
+                v-else-if="col.format"
+                :align="col.align || 'center'"
+                v-html="col.format(row[col.key])"
+              ></td>
+              <td v-else :align="col.align || 'center'">
+                {{ row[col.key] }}
+              </td>
+            </template>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <Center v-if="rows.length" class="pages">
+      <Clickable
+        icon="fas fa-chevron-left"
+        @click="prevPage"
+        design="plain"
+        :disabled="!canPrev"
+        v-tooltip="'Previous page of table rows'"
+      />
+      <span>{{ startRow + 1 }} to {{ endRow }} of {{ rows.length }}</span>
+      <Clickable
+        icon="fas fa-chevron-right"
+        @click="nextPage"
+        design="plain"
+        :disabled="!canNext"
+        v-tooltip="'Next page of table rows'"
+      />
+    </Center>
+    <Center v-else>
+      No Results
+    </Center>
   </div>
-  <Center v-if="rows.length" class="pages">
-    <Clickable
-      icon="fas fa-chevron-left"
-      @click="prevPage"
-      design="plain"
-      :disabled="!canPrev"
-      v-tooltip="'Previous page of table rows'"
-    />
-    <span>{{ startRow + 1 }} to {{ endRow }} of {{ rows.length }}</span>
-    <Clickable
-      icon="fas fa-chevron-right"
-      @click="nextPage"
-      design="plain"
-      :disabled="!canNext"
-      v-tooltip="'Next page of table rows'"
-    />
-  </Center>
-  <Center v-else>
-    No Results
-  </Center>
 </template>
 
 <script lang="ts">
@@ -183,62 +186,75 @@ export default defineComponent({
 
 <style scoped lang="scss">
 .table {
-  width: 100%;
   margin: 20px 0;
-  overflow-x: auto;
 
-  table {
-    width: 100%;
-    border-collapse: collapse;
+  .heading {
+    margin-bottom: 10px;
+    text-align: center;
+    font-weight: $medium;
   }
 
-  thead {
-    tr {
-      border-bottom: solid 2px $light-gray;
+  .scroll {
+    width: 100%;
+    overflow-x: auto;
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    thead {
+      tr {
+        border-bottom: solid 2px $light-gray;
+      }
+    }
+
+    th > * {
+      width: 100%;
+      padding: 5px;
+      font-weight: $semi-bold;
+      white-space: nowrap;
+    }
+
+    td {
+      padding: 5px;
+      overflow-wrap: break-word;
+    }
+
+    [align="left"] {
+      text-align: left;
+      justify-content: flex-start;
+    }
+
+    [align="right"] {
+      text-align: right;
+      justify-content: flex-end;
+    }
+
+    [align="center"] {
+      text-align: center;
+      justify-content: center;
+    }
+
+    .fas {
+      margin-left: 5px;
+    }
+
+    .fa-sort {
+      color: $light-gray;
     }
   }
 
-  th > * {
-    width: 100%;
-    padding: 5px;
-    font-weight: $semi-bold;
-    white-space: nowrap;
-  }
-
-  td {
-    padding: 5px;
-    overflow-wrap: break-word;
-  }
-
-  [align="left"] {
-    text-align: left;
-    justify-content: flex-start;
-  }
-
-  [align="right"] {
-    text-align: right;
-    justify-content: flex-end;
-  }
-
-  [align="center"] {
-    text-align: center;
-    justify-content: center;
-  }
-
-  .fas {
-    margin-left: 5px;
-  }
-
-  .fa-sort {
-    color: $light-gray;
-  }
-}
-
-@media (max-width: $phone) {
   .pages {
-    span {
-      width: 100%;
-      order: 1;
+    margin-top: 10px;
+  }
+
+  @media (max-width: $phone) {
+    .pages {
+      span {
+        width: 100%;
+        order: 1;
+      }
     }
   }
 }

--- a/src/views/api/TryItOut.vue
+++ b/src/views/api/TryItOut.vue
@@ -39,7 +39,7 @@
     </CodeBlock>
     <Center>
       <i>
-        All fields support
+        Most fields support
         <a
           href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html"
           >standard Elasticsearch query syntax</a
@@ -176,8 +176,8 @@ const requests: Requests = {
       },
       {
         name: "size",
-        example: "3",
-        tooltip: "How many results to return"
+        example: "1",
+        tooltip: "How many results to return (in this case, per search term)"
       }
     ],
     tooltip: "How to search for a list of genesets"

--- a/src/views/api/TryItOut.vue
+++ b/src/views/api/TryItOut.vue
@@ -140,7 +140,7 @@ const requests: Requests = {
       {
         name: "q",
         example: "glucose",
-        tooltip: "A list of search terms"
+        tooltip: "Search terms"
       },
       {
         name: "fields",

--- a/src/views/api/TryItOut.vue
+++ b/src/views/api/TryItOut.vue
@@ -140,7 +140,7 @@ const requests: Requests = {
       {
         name: "q",
         example: "glucose",
-        tooltip: "Search terms"
+        tooltip: "What to search for"
       },
       {
         name: "fields",
@@ -162,7 +162,7 @@ const requests: Requests = {
       {
         name: "q",
         example: "P13671,P00813,Q01740",
-        tooltip: "A list of search terms"
+        tooltip: "A list of separate searches"
       },
       {
         name: "scopes",

--- a/src/views/api/TryItOut.vue
+++ b/src/views/api/TryItOut.vue
@@ -177,7 +177,7 @@ const requests: Requests = {
       {
         name: "size",
         example: "1",
-        tooltip: "How many results to return (in this case, per search term)"
+        tooltip: "How many results to return (in this case, per search)"
       }
     ],
     tooltip: "How to search for a list of genesets"

--- a/src/views/api/TryItOut.vue
+++ b/src/views/api/TryItOut.vue
@@ -37,6 +37,15 @@
         <span v-if="index < fields.length - 1">&</span>
       </template>
     </CodeBlock>
+    <Center>
+      <i>
+        All fields support
+        <a
+          href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html"
+          >standard Elasticsearch query syntax</a
+        >, like <code>*</code> for wildcards
+      </i>
+    </Center>
     <Center width="150px">
       <CopyButton :text="this.code" subject="request" />
       <Clickable
@@ -131,14 +140,12 @@ const requests: Requests = {
       {
         name: "q",
         example: "glucose",
-        tooltip:
-          "Search terms. Accepts any Elasticsearch query syntax, e.g. * for wildcard."
+        tooltip: "A list of search terms"
       },
       {
         name: "fields",
-        example: "genes.name",
-        tooltip:
-          "Fields to return from each geneset. Accepts any Elasticsearch query syntax, e.g. * for wildcard."
+        example: "taxid,genes.name",
+        tooltip: "A list of fields to return from each geneset"
       },
       {
         name: "size",
@@ -148,28 +155,32 @@ const requests: Requests = {
     ],
     tooltip: "How to search for gensets by keywords"
   },
-  "Batch lookup": {
+  "Batch search": {
     method: "POST",
     path: "query/?",
     fields: [
       {
         name: "q",
-        example: "WP661,WP4875,WP4918",
-        tooltip: "Comma or plus separated list of genesets to lookup"
+        example: "P13671,P00813,Q01740",
+        tooltip: "A list of search terms"
+      },
+      {
+        name: "scopes",
+        example: "taxid,genes.uniprot",
+        tooltip: "A list of fields to search"
       },
       {
         name: "fields",
-        example: "genes.ensemblgene",
-        tooltip:
-          "Fields to return from each geneset. Accepts any Elasticsearch query syntax, e.g. * for wildcard."
+        example: "taxid,genes.name",
+        tooltip: "A list of fields to return from each geneset"
       },
       {
         name: "size",
-        example: "10",
+        example: "3",
         tooltip: "How many results to return"
       }
     ],
-    tooltip: "How to lookup a list of genesets by their mygeneset.info ids"
+    tooltip: "How to search for a list of genesets"
   }
 };
 

--- a/src/views/browse/Search.vue
+++ b/src/views/browse/Search.vue
@@ -81,10 +81,7 @@ export default defineComponent({
   },
   computed: {
     top(): string {
-      return Math.min(
-        100,
-        (this.results[0] as Json)?.total || 0
-      ).toLocaleString();
+      return Math.min(100, this.results.length || 0).toLocaleString();
     },
     total(): string {
       return ((this.results[0] as Json)?.total || 0).toLocaleString();

--- a/src/views/browse/Search.vue
+++ b/src/views/browse/Search.vue
@@ -11,7 +11,10 @@
         v-model="species"
       />
     </Center>
-    <Table :cols="cols" :rows="results" />
+    <Table :cols="cols" :rows="results">
+      <i class="fas fa-briefcase"></i>
+      <span>Top {{ top }} of {{ total }} total results</span>
+    </Table>
   </Section>
 </template>
 
@@ -41,7 +44,19 @@ const cols = [
   {
     key: "genes",
     name: "Genes",
-    align: "left"
+    align: "left",
+    format: (cell: Json) =>
+      [cell]
+        .flat()
+        .map(
+          gene =>
+            gene.name ||
+            [gene.ensemblgene].flat()[0] ||
+            [gene.mygene_id].flat()[0] ||
+            ""
+        )
+        .filter(gene => gene)
+        .join(", ")
   }
 ];
 
@@ -63,6 +78,17 @@ export default defineComponent({
       cols,
       results: []
     };
+  },
+  computed: {
+    top(): string {
+      return Math.min(
+        100,
+        (this.results[0] as Json)?.total || 0
+      ).toLocaleString();
+    },
+    total(): string {
+      return ((this.results[0] as Json)?.total || 0).toLocaleString();
+    }
   },
   methods: {
     async search() {


### PR DESCRIPTION
Closes #16 

- css tweaks
- return hit counts from search queries
- add results count for species search and geneset search
- refactor table component a bit
- add tooltips to api page query buttons
- add more queries to api page
- fix formatting of browse page results table genes