### PR TITLE
Incorporate comments from Nucleic Acids Research

### DIFF
--- a/src/api/genes.ts
+++ b/src/api/genes.ts
@@ -10,6 +10,7 @@ export interface _Gene {
   alias?: Array<string>;
   entrezgene?: Array<string>;
   ensemblgene?: Array<string>;
+  ensembl?: { gene: Array<string> };
   uniprot?: Array<string | { "Swiss-Prot": string }>;
   taxid?: number;
   notfound?: boolean;
@@ -21,8 +22,8 @@ export interface Gene {
   symbol: Array<string>;
   name: string;
   alias: Array<string>;
-  entrezgene: Array<string>;
-  ensemblgene: Array<string>;
+  entrez: Array<string>;
+  ensembl: Array<string>;
   uniprot: Array<string>;
   taxid: string;
   species?: Array<string>;
@@ -31,16 +32,16 @@ export interface Gene {
 // convert backend format to desired frontend format
 export const mapGene = (gene: _Gene): Gene => ({
   id: gene._id || gene.mygene_id || "",
-  name: gene.name || "",
-  taxid: String(gene.taxid) || "",
-  alias: gene.alias || [],
-  entrezgene: gene.entrezgene || [],
   symbol: gene.symbol || [],
-  ensemblgene: gene.ensemblgene || [],
+  name: gene.name || "",
+  alias: gene.alias || [],
+  entrez: gene.entrezgene || [],
+  ensembl: gene.ensemblgene || gene.ensembl?.gene || [],
   uniprot:
     gene.uniprot
       ?.map((u) => (typeof u === "string" ? u : u["Swiss-Prot"]))
       ?.filter((u) => u) || [],
+  taxid: String(gene.taxid) || "",
 });
 
 // get displayable label for gene with fallbacks
@@ -49,8 +50,8 @@ export const getGeneLabel = (gene: Gene) =>
   gene.name ||
   gene.id ||
   gene.alias[0] ||
-  gene.entrezgene[0] ||
-  gene.ensemblgene[0] ||
+  gene.entrez[0] ||
+  gene.ensembl[0] ||
   gene.uniprot[0];
 
 const biogps = "http://biogps.org/#goto=genereport&id=";
@@ -64,8 +65,8 @@ export const getGeneTooltip = (gene: Gene) =>
 <tr><td><b>Symbol</b></td><td>${gene.symbol.join(", ") || "-"}</td></tr>
 <tr><td><b>Name</b></td><td>${gene.name || "-"}</td></tr>
 <tr><td><b>Alias</b></td><td>${gene.alias.join(", ") || "-"}</td></tr>
-<tr><td><b>Entrez</b></td><td>${gene.entrezgene.join(", ") || "-"}</td></tr>
-<tr><td><b>Ensembl</b></td><td>${gene.ensemblgene.join(", ") || "-"}</td></tr>
+<tr><td><b>Entrez</b></td><td>${gene.entrez.join(", ") || "-"}</td></tr>
+<tr><td><b>Ensembl</b></td><td>${gene.ensembl.join(", ") || "-"}</td></tr>
 <tr><td><b>Uniprot</b></td><td>${gene.uniprot.join(", ") || "-"}</td></tr>
 <tr><td><b>Taxon</b></td><td>${gene.taxid || "-"}</td></tr>
 <tr><td><b>Links</b></td><td>
@@ -88,7 +89,7 @@ export const searchGenes = async (
   // dynamic params
   let method;
   if (Array.isArray(query)) {
-    params.set("q", query.join());
+    params.set("q", query.join(","));
     method = "POST";
   } else {
     if (query) params.set("q", query);

--- a/src/api/genes.ts
+++ b/src/api/genes.ts
@@ -53,20 +53,26 @@ export const getGeneLabel = (gene: Gene) =>
   gene.ensemblgene[0] ||
   gene.uniprot[0];
 
+const biogps = "http://biogps.org/#goto=genereport&id=";
+
 // get displayable tooltip for gene with more info
 export const getGeneTooltip = (gene: Gene) =>
-  [
-    "Gene details:",
-    "",
-    "ID: " + (gene.id || "-"),
-    "Symbol: " + (gene.symbol.join(", ") || "-"),
-    "Name: " + (gene.name || "-"),
-    "Alias: " + (gene.alias.join(", ") || "-"),
-    "Entrez: " + (gene.entrezgene.join(", ") || "-"),
-    "Ensembl: " + (gene.ensemblgene.join(", ") || "-"),
-    "Uniprot: " + (gene.uniprot.join(", ") || "-"),
-    "Taxon: " + (gene.taxid || "-"),
-  ].join("<br/>");
+  `
+<table>
+<tr><th>Gene details</th></tr>
+<tr><td><b>ID</b></td><td>${gene.id || "-"}</td></tr>
+<tr><td><b>Symbol</b></td><td>${gene.symbol.join(", ") || "-"}</td></tr>
+<tr><td><b>Name</b></td><td>${gene.name || "-"}</td></tr>
+<tr><td><b>Alias</b></td><td>${gene.alias.join(", ") || "-"}</td></tr>
+<tr><td><b>Entrez</b></td><td>${gene.entrezgene.join(", ") || "-"}</td></tr>
+<tr><td><b>Ensembl</b></td><td>${gene.ensemblgene.join(", ") || "-"}</td></tr>
+<tr><td><b>Uniprot</b></td><td>${gene.uniprot.join(", ") || "-"}</td></tr>
+<tr><td><b>Taxon</b></td><td>${gene.taxid || "-"}</td></tr>
+<tr><td><b>Links</b></td><td>
+<a href="${biogps}${gene.id || "-"}" target="_blank">on BioGPS</a>
+</td></tr>
+</table>
+`;
 
 // search genes by keyword
 export const searchGenes = async (

--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -1,6 +1,5 @@
 import { mapValues } from "lodash";
 import { mygeneset, request } from ".";
-import { searchGenesets } from "./genesets";
 
 const usageUrl =
   "https://biothings-data.s3.us-west-2.amazonaws.com/stats/biothings_30day_usage.json";
@@ -11,17 +10,6 @@ export const getMetadata = async (): Promise<Metadata> => {
   const url = `${mygeneset}/metadata`;
   const type = "getMetadata";
   const response = await request<_Metadata>(url, type);
-
-  // calculate geneset numbers
-  const totalGenesets = response.stats.total;
-  const curatedGenesets = Object.entries(response.src)
-    .map(([key, { stats }]) => stats[key])
-    .reduce((total, value) => total + value, 0);
-  const userGenesets = totalGenesets - curatedGenesets;
-  const publicUserGenesets = (
-    await searchGenesets("getPublicUserGenesets", "_exists_:author")
-  ).total;
-  const privateUserGenesets = userGenesets - publicUserGenesets;
 
   // other metadata
   const curatedSources = Object.keys(response.src);
@@ -35,15 +23,12 @@ export const getMetadata = async (): Promise<Metadata> => {
   }
 
   return {
-    totalGenesets,
-    userGenesets,
-    publicUserGenesets,
-    privateUserGenesets,
-    curatedGenesets,
+    stats: response.stats,
     curatedSources,
     requests: usage["mygeneset.info"]?.no_of_requests || 0,
     ips: usage["mygeneset.info"]?.no_of_unique_ips || 0,
     curatedMeta: mapValues(response.src, (value) => ({
+      name: value.description || "",
       url: value.url || "",
       logo: value.logo || "",
       uploaded: value.upload_date ? new Date(value.upload_date) : undefined,
@@ -58,12 +43,16 @@ export const getMetadata = async (): Promise<Metadata> => {
 interface _Metadata {
   stats: {
     total: number;
+    curated: number;
+    user: number;
+    anonymous: number;
   };
   src: {
     [key: string]: {
       stats: {
         [key: string]: number;
       };
+      description?: string;
       url?: string;
       logo?: string;
       upload_date?: string;
@@ -82,16 +71,13 @@ interface _Usage {
 
 // for frontend
 export interface Metadata {
-  // total number of genesets
-  totalGenesets: number;
-  // number of user genesets
-  userGenesets: number;
-  // number of public user genesets
-  publicUserGenesets: number;
-  // number of private user genesets
-  privateUserGenesets: number;
-  // number of curated genesets
-  curatedGenesets: number;
+  // numbers of genesets
+  stats: {
+    total: number;
+    curated: number;
+    user: number;
+    anonymous: number;
+  };
   // names/keys of distinct sources for curated genesets
   curatedSources: Array<string>;
   // number of requests in last 30 days
@@ -101,6 +87,7 @@ export interface Metadata {
   // metadata about curated genesets
   curatedMeta: {
     [key: string]: {
+      name?: string;
       url?: string;
       logo?: string;
       uploaded?: Date;

--- a/src/api/species.ts
+++ b/src/api/species.ts
@@ -62,7 +62,7 @@ export const searchSpecies = async (
   let method;
   if (query) {
     if (Array.isArray(query)) {
-      params.set("q", query.join());
+      params.set("q", query.join(","));
       method = "POST";
     } else params.set("q", query);
   } else {

--- a/src/api/species.ts
+++ b/src/api/species.ts
@@ -41,13 +41,15 @@ export const getSpeciesLabel = (species: Species) =>
 
 // get displayable tooltip for species with more info
 export const getSpeciesTooltip = (species: Species) =>
-  [
-    "Species details:",
-    "",
-    "ID: " + (species.id || "-"),
-    "Common: " + (species.common || "-"),
-    "Scientific: " + (species.scientific || "-"),
-  ].join("<br/>");
+  `
+<table>
+<tr><th>Species details</th></tr>
+<tr><td><b>ID</b></td><td>${species.id || "-"}</td></tr>
+<tr><td><b>Common</b></td><td>${species.common || "-"}</td></tr>
+<tr><td><b>Scientific</b></td><td>${species.scientific || "-"}</td></tr>
+</td></tr>
+</table>
+`;
 
 // search for species by keyword
 export const searchSpecies = async (

--- a/src/assets/TheLogo.vue
+++ b/src/assets/TheLogo.vue
@@ -112,7 +112,7 @@
   </svg>
 </template>
 
-<style>
+<style lang="scss" scoped>
 .shadow {
   fill: #00000010;
   animation: shadow 4s cubic-bezier(0.5, 0, 0.5, 1) forwards infinite;

--- a/src/components/AppCodeInput.vue
+++ b/src/components/AppCodeInput.vue
@@ -21,6 +21,7 @@ interface Props {
 defineProps<Props>();
 
 interface Emits {
+  // two-way binding value
   (event: "update:modelValue", value: string): void;
 }
 

--- a/src/components/AppHero.vue
+++ b/src/components/AppHero.vue
@@ -67,11 +67,11 @@ defineProps<Props>();
 </script>
 
 <style scoped lang="scss">
-$breakpoint: 500px;
+$breakpoint: 650px;
 
 .hero {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, 120px);
   gap: 40px;
 }
 

--- a/src/components/AppInput.vue
+++ b/src/components/AppInput.vue
@@ -51,7 +51,7 @@ import { nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { cloneDeep, debounce, isEqual } from "lodash";
 
 interface Props {
-  // state
+  // internal input state
   modelValue?: string;
   // placeholder string when nothing typed in
   placeholder?: string;

--- a/src/components/AppNumber.vue
+++ b/src/components/AppNumber.vue
@@ -1,0 +1,41 @@
+<template>
+  <label>
+    {{ text }}:
+    <input
+      :value="modelValue"
+      class="number"
+      type="number"
+      @change="(event: Event) => emit('update:modelValue', Number((event?.target as HTMLInputElement).value) || 0)"
+    />
+  </label>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  // internal input state
+  modelValue: number;
+  // text to show in label
+  text: string;
+}
+
+defineProps<Props>();
+
+interface Emits {
+  // two-way binding value
+  (event: "update:modelValue", value: number): void;
+}
+
+const emit = defineEmits<Emits>();
+</script>
+
+<style scoped lang="scss">
+.number {
+  width: 100px;
+  margin: 0;
+  padding: 5px 10px;
+  border: solid 2px $theme;
+  border-radius: $rounded;
+  color: $black;
+  font-size: 1rem;
+}
+</style>

--- a/src/components/AppSelect.vue
+++ b/src/components/AppSelect.vue
@@ -1,13 +1,20 @@
 <template>
-  <select
-    :value="modelValue"
-    class="select"
-    @change="(event: Event) => emit('update:modelValue', (event?.target as HTMLSelectElement).value || '')"
-  >
-    <option v-for="(option, index) in options" :key="index" :value="option.key">
-      {{ option.text }}
-    </option>
-  </select>
+  <label>
+    {{ text }}:
+    <select
+      :value="modelValue"
+      class="select"
+      @change="(event: Event) => emit('update:modelValue', (event?.target as HTMLSelectElement).value || '')"
+    >
+      <option
+        v-for="(option, index) in options"
+        :key="index"
+        :value="option.key"
+      >
+        {{ option.text }}
+      </option>
+    </select>
+  </label>
 </template>
 
 <script setup lang="ts">
@@ -18,7 +25,6 @@ export type Options = Array<{
   key: string;
   // text to show for option
   text: string;
-
   // allow any other params (will be ignored)
   [key: string]: unknown;
 }>;
@@ -28,11 +34,14 @@ interface Props {
   modelValue: Option;
   // options to select from
   options: Options;
+  // label text
+  text: string;
 }
 
 defineProps<Props>();
 
 interface Emits {
+  // two-way binding value
   (event: "update:modelValue", value: string): void;
 }
 

--- a/src/components/AppTable.vue
+++ b/src/components/AppTable.vue
@@ -124,7 +124,7 @@ import { computed, StyleValue } from "vue";
 import AppButton from "./AppButton.vue";
 
 // eslint-disable-next-line
-export type Row = Record<string, any>;
+export type Row = any;
 
 export interface Col {
   // unique id of column

--- a/src/global/styles.scss
+++ b/src/global/styles.scss
@@ -75,7 +75,7 @@ a {
 }
 
 a:hover {
-  color: $black;
+  color: currentColor;
 }
 
 // inputs

--- a/src/global/tippy.ts
+++ b/src/global/tippy.ts
@@ -15,10 +15,9 @@ export const options = {
     duration: 200,
     offset: [13, 13],
     allowHTML: true,
+    interactive: true,
+    appendTo: () => document.body,
     onShow,
     onHide,
   },
 };
-
-// https://github.com/KABBOUCHI/vue-tippy/issues/140
-export const appendToBody = (): Element => document.body;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ for (const [name, component] of Object.entries(components))
 // run app
 (async () => {
   // use mock api calls when developing locally, like we do during tests
-  // if (process.env.NODE_ENV === "development")
-  //   await setupWorker(...handlers).start({ onUnhandledRequest: "bypass" });
+  if (process.env.NODE_ENV === "development")
+    await setupWorker(...handlers).start({ onUnhandledRequest: "bypass" });
 
   // render app
   app.mount("#app");

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ for (const [name, component] of Object.entries(components))
 // run app
 (async () => {
   // use mock api calls when developing locally, like we do during tests
-  if (process.env.NODE_ENV === "development")
-    await setupWorker(...handlers).start({ onUnhandledRequest: "bypass" });
+  // if (process.env.NODE_ENV === "development")
+  //   await setupWorker(...handlers).start({ onUnhandledRequest: "bypass" });
 
   // render app
   app.mount("#app");

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -1,9 +1,5 @@
 // test if url is link to external resource (on a different domain/host)
-export const isExternalLink = (url = "") => {
-  if (url.includes("mailto:")) return true;
-  try {
-    return new URL(url).hostname !== window.location.hostname;
-  } catch (error) {
-    return false;
-  }
-};
+export const isExternalLink = (url = "") =>
+  url.startsWith("mailto:") ||
+  url.startsWith("https:") ||
+  url.startsWith("http:");

--- a/src/views/about/SectionFaqs.vue
+++ b/src/views/about/SectionFaqs.vue
@@ -36,15 +36,38 @@
       <p>
         The genes themselves come from the BioThings
         <AppLink to="https://mygene.info/">MyGene</AppLink> project, which
-        contains millions of genes from thousands of species. The built-in
-        genesets come from various public sources:
+        contains millions of genes from thousands of species. All of the genes
+        from MyGene.info can be searched for and selected in the
+        <AppLink to="/build">geneset builder</AppLink>
+        .
+      </p>
+      <p>
+        Detailed information on the sources of gene annotations in MyGene.info
+        can be found
+        <AppLink
+          to="https://docs.mygene.info/en/latest/doc/data.html#data-sources"
+          >here (major sources)</AppLink
+        >
+        and
+        <AppLink
+          to="https://docs.mygene.info/en/latest/doc/data.html#available-fields"
+          >here (additional sources and annotation fields)</AppLink
+        >. Detailed information on the species coverage of MyGene.info can be
+        found
+        <AppLink to="https://docs.mygene.info/en/latest/doc/data.html#species"
+          >here</AppLink
+        >.
+      </p>
+      <p>
+        The built-in/curated genesets are publicly-accessible and come from the
+        following sources:
       </p>
       <ul>
         <li
-          v-for="(source, key, index) in $store.state.metadata?.curatedMeta"
+          v-for="(source, index) in $store.state.metadata?.curatedMeta"
           :key="index"
         >
-          <AppLink :to="source.url">{{ String(key).toUpperCase() }}</AppLink>
+          <AppLink :to="source.url">{{ source.name }}</AppLink>
         </li>
       </ul>
 

--- a/src/views/about/SectionFaqs.vue
+++ b/src/views/about/SectionFaqs.vue
@@ -52,10 +52,10 @@
       <p>
         User-created genesets are available right away. Built-in genesets
         (listed above) are
-        <AppLink to="http://mygeneset.info/v1/metadata"
+        <AppLink to="https://mygeneset.info/v1/metadata"
           >updated from their original sources weekly</AppLink
         >. The genes themselves (their annotation data) are also
-        <AppLink to="http://mygene.info/v1/metadata">updated weekly</AppLink>.
+        <AppLink to="https://mygene.info/metadata">updated weekly</AppLink>.
       </p>
 
       <AppHeading level="3">What's behind MyGeneset?</AppHeading>

--- a/src/views/browse/SectionBrowse.vue
+++ b/src/views/browse/SectionBrowse.vue
@@ -21,8 +21,13 @@
 
       <!-- filters -->
       <AppFlex h-align="left" gap="small">
-        Search by type:
-        <AppSelect v-model="type" :options="typeOptions" />
+        <AppSelect
+          v-model="type"
+          text="Search by type"
+          :options="typeOptions"
+        />
+        <AppNumber v-model="countMin" text="Min genes" />
+        <AppNumber v-model="countMax" text="Max genes" />
       </AppFlex>
       <AppFlex v-if="type === 'curated'" h-align="left" gap="small">
         Source:
@@ -61,6 +66,7 @@ import AppSelect, {
 import AppChecklist, {
   Options as ChecklistOptions,
 } from "@/components/AppChecklist.vue";
+import AppNumber from "@/components/AppNumber.vue";
 import { Sort } from "@/components/AppTable.vue";
 import AppStatus from "@/components/AppStatus.vue";
 import { Geneset, searchGenesets } from "@/api/genesets";
@@ -85,6 +91,10 @@ const typeOptions: SelectOptions = [
 
 // selected type of geneset
 const type = ref(typeOptions[0].key);
+
+// number of genes
+const countMin = ref(0);
+const countMax = ref(999999);
 
 // selected sources of curated genesets
 const sources = ref<ChecklistOptions>([]);
@@ -139,6 +149,7 @@ const search = async () => {
   }
   if (type.value === "anonymous")
     fields = "NOT _exists_:author AND NOT _exists_:source";
+  fields += ` count:[${countMin.value} TO ${countMax.value}]`;
 
   // assembled query string
   const query = [keywords.value, fields].filter((part) => part).join(" AND ");
@@ -171,9 +182,15 @@ const search = async () => {
 // run search on load
 onMounted(search);
 
-// run search on state change
-watch([start, perPage, sort, type], search);
+// when any search params change, re-run search
+watch(
+  [keywords, species, type, sources, countMin, countMax, sort, start, perPage],
+  search
+);
 
-// reset page to 0 when search changes
-watch([keywords, species, type, sources], () => (start.value = 0));
+// reset page to 0 when search params (except start) change
+watch(
+  [keywords, species, type, sources, countMin, countMax, sort, perPage],
+  () => (start.value = 0)
+);
 </script>

--- a/src/views/geneset/SectionAdd.vue
+++ b/src/views/geneset/SectionAdd.vue
@@ -7,7 +7,7 @@
       <AppInput
         v-model="keywords"
         v-tippy="'Comma/tab/newline-separate to perform batch searches'"
-        placeholder="Search genes by keyword"
+        placeholder="Search genes by keyword, symbol, alias, entrez, ensemble, uniprot"
         icon="search"
         mode="switchable"
         @change="search"

--- a/src/views/geneset/SectionDownload.vue
+++ b/src/views/geneset/SectionDownload.vue
@@ -5,8 +5,7 @@
     <!-- options -->
     <AppFlex>
       <AppFlex gap="small">
-        Format:
-        <AppSelect v-model="format" :options="formatOptions" />
+        <AppSelect v-model="format" text="Format" :options="formatOptions" />
         <AppCheckbox
           v-model="transpose"
           v-tippy="'Flip gene rows/columns'"

--- a/src/views/geneset/SectionSelected.vue
+++ b/src/views/geneset/SectionSelected.vue
@@ -21,10 +21,7 @@
       </AppFlex>
 
       <!-- sort -->
-      <AppFlex flow="inline" gap="small">
-        Sort by:
-        <AppSelect v-model="sort" :options="sortOptions" />
-      </AppFlex>
+      <AppSelect v-model="sort" text="Sort by" :options="sortOptions" />
     </AppFlex>
 
     <!-- list of genes -->

--- a/src/views/home/SectionHero.vue
+++ b/src/views/home/SectionHero.vue
@@ -2,27 +2,33 @@
   <AppSection>
     <AppHero icon="dna">
       <template #aTop>
-        {{ userGenesets ? userGenesets.toLocaleString() : "-" }}
+        {{ $store.state.metadata?.stats.total?.toLocaleString() || "-" }}
+      </template>
+
+      <template #aBottom>total genesets</template>
+
+      <template #bTop>
+        {{ $store.state.metadata?.stats.curated?.toLocaleString() || "-" }}
+      </template>
+
+      <template #bBottom>curated genesets</template>
+    </AppHero>
+    <AppHero icon="dna">
+      <template #aTop>
+        {{ $store.state.metadata?.stats.user?.toLocaleString() || "-" }}
       </template>
 
       <template #aBottom>user genesets</template>
 
       <template #bTop>
-        {{ curatedGenesets ? curatedGenesets.toLocaleString() : "-" }}
+        {{ $store.state.metadata?.stats.anonymous?.toLocaleString() || "-" }}
       </template>
 
-      <template #bBottom>curated genesets</template>
+      <template #bBottom>anonymous genesets</template>
     </AppHero>
   </AppSection>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
-import { useStore } from "@/store";
 import AppHero from "@/components/AppHero.vue";
-
-const store = useStore();
-
-const userGenesets = computed(() => store.state.metadata?.userGenesets);
-const curatedGenesets = computed(() => store.state.metadata?.curatedGenesets);
 </script>


### PR DESCRIPTION
- pull ensembl from `ensembl` key in addition to `ensemblgene` key
- change gene and species tooltips to table display
- add biogps link to gene tooltips
- take global stats from metadata endpoint instead of computing it in frontend
- add species column to geneset table
- add number input component
- add label to select component
- make tooltips interactive/hoverable
- fix isExternalLink
- update FAQ and other about page text
- allow browsing genesets by min and max gene counts
- tweak gene search box placeholder text